### PR TITLE
Actualizar variables de entorno en vercel.json para eliminar el prefi…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,8 +6,8 @@
   "installCommand": "npm install --prefix apps/frontend",
   "framework": "nextjs",
   "env": {
-    "NEXT_PUBLIC_SUPABASE_URL": "@supabase-url",
-    "NEXT_PUBLIC_SUPABASE_ANON_KEY": "@supabase-anon-key",
+    "SUPABASE_URL": "@supabase-url",
+    "SUPABASE_ANON_KEY": "@supabase-anon-key",
     "SUPABASE_SERVICE_ROLE_KEY": "@supabase-service-role-key",
     "NEXT_PUBLIC_APP_ENV": "@app-env",
     "NEXT_PUBLIC_ZOHO_CLIENT_ID": "@zoho-client-id",


### PR DESCRIPTION
This pull request includes a small but important change to the `vercel.json` configuration file. The environment variable names for the Supabase URL and anonymous key have been updated to remove the `NEXT_PUBLIC_` prefix, aligning them with a non-public naming convention.

* [`vercel.json`](diffhunk://#diff-a3265310f552fb66876e8bfe8809737e59e5ba946bdf39138b44d9baf4e21240L9-R10): Renamed `NEXT_PUBLIC_SUPABASE_URL` to `SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` to `SUPABASE_ANON_KEY`, reflecting a shift to non-public environment variable naming.…jo NEXT_PUBLIC en SUPABASE_URL y SUPABASE_ANON_KEY.