### PR TITLE
fix: restore missing Supabase anon key in Authorization header

### DIFF
--- a/apps/frontend/src/config/api.ts
+++ b/apps/frontend/src/config/api.ts
@@ -215,6 +215,7 @@ export const customFetch = async <T>(
 
     // Añadir cabeceras de autorización para Supabase Edge Functions
     if (supabaseAnonKey) {
+      defaultHeaders['Authorization'] = `Bearer ${supabaseAnonKey}`;
       defaultHeaders['apikey'] = supabaseAnonKey;
     }
 


### PR DESCRIPTION
🔧 CRITICAL FIX: The Authorization header was showing 'none' instead of the Supabase anon key

- Added back the missing line: defaultHeaders['Authorization'] = `Bearer ${supabaseAnonKey}`
- This was causing the 401 'Missing authorization header' error on unified-auth
- The selective logic was working correctly, but the base Supabase auth was missing

DEBUG logs show:
- requiresUserAuth: false ✅ (correct for unified-auth)
- hasSupabaseKey: true ✅ (env var is present)
- Authorization: 'none' ❌ (was the problem)

Now should show Authorization: 'Bearer <supabase_anon_key>...' ✅